### PR TITLE
sign in page btn deformed correction

### DIFF
--- a/app/assets/stylesheets/signins/_signup.scss
+++ b/app/assets/stylesheets/signins/_signup.scss
@@ -10,9 +10,16 @@ margin-top: 5vh;
  margin-top: 15vh;
 }
 
-.form-actions {
- margin: 20px auto;
- border-radius:20px;
- padding:10px 20px;
- background: linear-gradient(90deg, rgba(115,255,205,1) 14%, rgba(0,212,255,1) 85%); 
+.sign-up-page-btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
+    width: 189px;
+    height: 42px;
+    background: linear-gradient(90deg, rgba(115,255,205,1) 14%, rgba(0,212,255,1) 85%);
+    box-sizing: border-box;
+    border-radius: 26px;
+    color: black;
+    font-size: 18px;
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -20,7 +20,7 @@
                   input_html: { autocomplete: "new-password" } %>
     </div>
 
-    <div class="form-actions">
+    <div class="form-actions sign-up-page-btn">
       <%= f.button :submit, "Sign up" %>
     </div>
   <% end %>


### PR DESCRIPTION
sign up page btn setting deformed the sign up btn in the sign in landing page. This push is to correct the styling influenced by the previous push.